### PR TITLE
Fix PeekNamedPipe Method

### DIFF
--- a/Drone/Interop/Methods.cs
+++ b/Drone/Interop/Methods.cs
@@ -208,15 +208,19 @@ public static class Methods
         return result;
     }
 
-    public static bool PeekNamedPipe(IntPtr hPipe)
+    public static bool PeekNamedPipe(IntPtr hPipe, ref uint nbBytesAvailable)
     {
-        object[] parameters = { hPipe, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, (uint)0, IntPtr.Zero };
-        
-        return (bool)Generic.DynamicApiInvoke(
+        object[] parameters = { hPipe, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, nbBytesAvailable, IntPtr.Zero };
+
+        var result = (bool)Generic.DynamicApiInvoke(
             "kernel32.dll",
             "PeekNamedPipe",
             typeof(PeekNamedPipe),
             ref parameters);
+
+        nbBytesAvailable = (uint)parameters[4];
+
+        return result;
     }
 
     public static bool FreeLibrary(IntPtr hModule)

--- a/Drone/Utilities/Extensions.cs
+++ b/Drone/Utilities/Extensions.cs
@@ -50,7 +50,12 @@ public static class Extensions
     public static bool DataAvailable(this PipeStream pipe)
     {
         var hPipe = pipe.SafePipeHandle.DangerousGetHandle();
-        return Interop.Methods.PeekNamedPipe(hPipe);
+        uint nbBytesAvailable = 0;
+        bool result = Interop.Methods.PeekNamedPipe(hPipe, ref nbBytesAvailable);
+        if (result == false)
+            throw new System.ComponentModel.Win32Exception("Named Pipe is not available.");
+
+        return nbBytesAvailable > 0;
     }
 
     public static async Task<byte[]> ReadStream(this Stream stream)


### PR DESCRIPTION
The current use of PeekNamedPipe does not work properly.
As the result of the API call to PeekNamedPipe only indicates whether the call is successful but does not provide any information about the availability of data.
In the Drone program, the thread is then blocked on the "pipe.ReadStream()", preventing the loop to operate.

I changed it to effectively check the number of bytes available.
Also, I added a throw when the call is not succeeding which will enable to properly close the communicator using the OnException event (I think it was already working because the pipe.ReadStream throws an exception when the pipe is closed).